### PR TITLE
Skript integration

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -15,7 +15,9 @@
         <property name="fileExtensions" value="java"/>
     </module>
     <module name="SuppressWarningsFilter" />
-    <module name="NewlineAtEndOfFile"/>
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
     <module name="TreeWalker">
         <module name="SuppressWarningsHolder" />
         <module name="AnnotationUseStyle"/>

--- a/docs/skript.md
+++ b/docs/skript.md
@@ -1,41 +1,48 @@
 ## Events
 
-### On module change status
-
-Trigger on module enable/disable/toggles
-
-#### Pattern
- 
-`module[s] ((change state|toggle[d])|enable[d]|disable[d]`
-
-#### Examples:
-
-`on module toggled` - Called whenever any module is toggled
-
-`on modules enabled` - Called whenever any module is enabled
+ - On module change status
+   - Description: Trigger on module enable/disable/toggles
+   - Pattern: `module[s] ((change state|toggle[d])|enable[d]|disable[d])`
+   - Examples:
+     - `on module toggled` - Called whenever any module is toggled
+     - `on modules enabled` - Called whenever any module is enabled
 
 ## Expressions
 
-### Module
-
-Get a module by its name
-
-#### Pattern
-
-`[the] module[s] called %strings%`
-
+- Get module by name
+  - Pattern: `[the] module[s] called %strings%`
+  
+- Get module's name
+  - Patterns: 
+    - `[the] name[s] of %modules%"`
+    - `%modules%'[s] name`
+  
+- Get module's enabled status (boolean)
+  - Patterns: 
+    - `[the] [enabled] status[es] of %modules%"`
+    - `"%modules%'[s] [enabled] status[es]`
+  
+- Get golden head heal amount
+  - Patterns: 
+    - `[the] heal amount of %module%`
+    - `"%module%'[s] heal amount`
+  
 ## Conditions
 
-### Check enabled/disabled
+- Check module status
+  - Description: Checks if all of the modules requested are enabled/disabled
+  - Pattern: `if %modules?% (is|are) (enabled|disabled)`
+  - Examples:
+    - `if the module "PVP" is enabled:`
+    - `if all modules are disabled:`
+    
+## Effects
 
-Checks if all of the provided modules are enabled or not
-
-#### Pattern
-
-`if %modules?% (is|are) (enabled|disabled)`
-
-#### Examples
-
-`if the module "PVP" is enabled:`
-
-`if all modules are disabled:`
+- Change status of module
+  - Description: Enables/Disables/Toggles the request modules
+  - Pattern: `((change state|toggle[d])|enable[d]|disable[d]) %modules%`
+  - Examples:
+    - `disable all modules`
+    - `enable the module called "PvP"`
+    - `disable the modules called "GoldenHeads", "ExtendedSaturation" and "ChatHealth"`
+    

--- a/docs/skript.md
+++ b/docs/skript.md
@@ -1,0 +1,41 @@
+## Events
+
+### On module change status
+
+Trigger on module enable/disable/toggles
+
+#### Pattern
+ 
+`module[s] ((change state|toggle[d])|enable[d]|disable[d]`
+
+#### Examples:
+
+`on module toggled` - Called whenever any module is toggled
+
+`on modules enabled` - Called whenever any module is enabled
+
+## Expressions
+
+### Module
+
+Get a module by its name
+
+#### Pattern
+
+`[the] module[s] called %strings%`
+
+## Conditions
+
+### Check enabled/disabled
+
+Checks if all of the provided modules are enabled or not
+
+#### Pattern
+
+`if %modules?% (is|are) (enabled|disabled)`
+
+#### Examples
+
+`if the module "PVP" is enabled:`
+
+`if all modules are disabled:`

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
             <name>uhc.gg-releases</name>
             <url>http://repo.uhc.gg/libs-release-local</url>
         </repository>
+        <repository>
+            <id>njol-repo</id>
+            <url>http://maven.njol.ch/repo/</url>
+        </repository>
     </repositories>
 
     <distributionManagement>
@@ -72,6 +76,12 @@
             <version>0.8.18</version>
             <type>jar</type>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.njol</groupId>
+            <artifactId>skript</artifactId>
+            <version>2.2-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.typesafe</groupId>

--- a/src/main/java/gg/uhc/uhc/UHC.java
+++ b/src/main/java/gg/uhc/uhc/UHC.java
@@ -69,6 +69,7 @@ import gg.uhc.uhc.modules.timer.TimerModule;
 import gg.uhc.uhc.modules.whitelist.WhitelistClearCommand;
 import gg.uhc.uhc.modules.whitelist.WhitelistOnlineCommand;
 import gg.uhc.uhc.modules.xp.NerfQuartzXPModule;
+import gg.uhc.uhc.skript.SkriptHook;
 
 import com.google.common.base.Optional;
 import com.typesafe.config.Config;
@@ -157,6 +158,8 @@ public class UHC extends JavaPlugin {
         );
         registry.register(new HeadDropsModule(headProvider));
         registry.register(new DeathStandsModule());
+
+        setupPluginHooks();
 
         setupTeamCommands();
 
@@ -265,6 +268,12 @@ public class UHC extends JavaPlugin {
         teamrequest.registerSubcommand("request", new TeamRequestCommand(requestMessages, requestManager));
         teamrequest.registerSubcommand("list", new RequestListCommand(requestMessages, requestManager));
         setupCommand(teamrequest, "teamrequest");
+    }
+
+    protected void setupPluginHooks() {
+        if (getServer().getPluginManager().getPlugin("Skript") != null) {
+            SkriptHook.register(this);
+        }
     }
 
     protected void setupProtocolLibModules() {

--- a/src/main/java/gg/uhc/uhc/modules/DisableableModule.java
+++ b/src/main/java/gg/uhc/uhc/modules/DisableableModule.java
@@ -31,8 +31,7 @@ import gg.uhc.uhc.ItemStackNBTStringFetcher;
 import gg.uhc.uhc.inventory.ClickHandler;
 import gg.uhc.uhc.inventory.IconInventory;
 import gg.uhc.uhc.inventory.IconStack;
-import gg.uhc.uhc.modules.events.ModuleDisableEvent;
-import gg.uhc.uhc.modules.events.ModuleEnableEvent;
+import gg.uhc.uhc.modules.events.ModuleChangeStatusEvent;
 
 import com.google.common.collect.ImmutableMap;
 import net.md_5.bungee.api.ChatColor;
@@ -168,7 +167,7 @@ public abstract class DisableableModule extends Module implements ClickHandler {
     public final boolean enable() {
         if (isEnabled()) return false;
 
-        final ModuleEnableEvent event = new ModuleEnableEvent(this);
+        final ModuleChangeStatusEvent event = new ModuleChangeStatusEvent(this, true);
         Bukkit.getPluginManager().callEvent(event);
 
         if (event.isCancelled()) return false;
@@ -185,7 +184,7 @@ public abstract class DisableableModule extends Module implements ClickHandler {
     public final boolean disable() {
         if (!isEnabled()) return false;
 
-        final ModuleDisableEvent event = new ModuleDisableEvent(this);
+        final ModuleChangeStatusEvent event = new ModuleChangeStatusEvent(this, false);
         Bukkit.getPluginManager().callEvent(event);
 
         if (event.isCancelled()) return false;

--- a/src/main/java/gg/uhc/uhc/modules/events/ModuleChangeStatusEvent.java
+++ b/src/main/java/gg/uhc/uhc/modules/events/ModuleChangeStatusEvent.java
@@ -1,6 +1,6 @@
 /*
  * Project: UHC
- * Class: gg.uhc.uhc.modules.events.ModuleEnableEvent
+ * Class: gg.uhc.uhc.modules.ModuleChangeStatusEvent
  *
  * The MIT License (MIT)
  *
@@ -29,17 +29,23 @@ package gg.uhc.uhc.modules.events;
 
 import gg.uhc.uhc.modules.DisableableModule;
 
+import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
-public class ModuleEnableEvent extends Event {
+public class ModuleChangeStatusEvent extends Event implements Cancellable {
     private static final HandlerList HANDLERS = new HandlerList();
 
-    protected boolean cancelled;
     protected final DisableableModule module;
+    protected final boolean from;
+    protected final boolean to;
 
-    public ModuleEnableEvent(DisableableModule module) {
+    protected boolean cancelled;
+
+    public ModuleChangeStatusEvent(DisableableModule module, boolean to) {
         this.module = module;
+        this.from = module.isEnabled();
+        this.to = to;
     }
 
     @Override
@@ -61,5 +67,13 @@ public class ModuleEnableEvent extends Event {
 
     public void setCancelled(boolean cancelled) {
         this.cancelled = cancelled;
+    }
+
+    public boolean isEnabled() {
+        return from;
+    }
+
+    public boolean willBeEnabled() {
+        return to;
     }
 }

--- a/src/main/java/gg/uhc/uhc/modules/health/HardcoreHeartsModule.java
+++ b/src/main/java/gg/uhc/uhc/modules/health/HardcoreHeartsModule.java
@@ -30,7 +30,7 @@ package gg.uhc.uhc.modules.health;
 import gg.uhc.uhc.modules.Module;
 import gg.uhc.uhc.modules.ModuleRegistry;
 import gg.uhc.uhc.modules.autorespawn.AutoRespawnModule;
-import gg.uhc.uhc.modules.events.ModuleDisableEvent;
+import gg.uhc.uhc.modules.events.ModuleChangeStatusEvent;
 
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.ProtocolLibrary;
@@ -77,8 +77,8 @@ public class HardcoreHeartsModule extends Module implements Listener {
     }
 
     @EventHandler(priority = EventPriority.HIGH)
-    public void on(ModuleDisableEvent event) {
-        if (event.getModule() == respawnModule) event.setCancelled(true);
+    public void on(ModuleChangeStatusEvent event) {
+        if (!event.willBeEnabled() && event.getModule() == respawnModule) event.setCancelled(true);
     }
 
     class HardcoreHeartsListener extends PacketAdapter {

--- a/src/main/java/gg/uhc/uhc/modules/team/prefixes/PrefixColourPredicate.java
+++ b/src/main/java/gg/uhc/uhc/modules/team/prefixes/PrefixColourPredicate.java
@@ -27,7 +27,6 @@
 
 package gg.uhc.uhc.modules.team.prefixes;
 
-
 import com.google.common.base.Predicate;
 import org.bukkit.ChatColor;
 

--- a/src/main/java/gg/uhc/uhc/modules/timer/TimeConverter.java
+++ b/src/main/java/gg/uhc/uhc/modules/timer/TimeConverter.java
@@ -27,7 +27,6 @@
 
 package gg.uhc.uhc.modules.timer;
 
-
 import gg.uhc.flagcommands.joptsimple.ValueConversionException;
 import gg.uhc.flagcommands.joptsimple.ValueConverter;
 import gg.uhc.uhc.util.TimeUtil;

--- a/src/main/java/gg/uhc/uhc/skript/CondDisableableModuleEnabled.java
+++ b/src/main/java/gg/uhc/uhc/skript/CondDisableableModuleEnabled.java
@@ -1,0 +1,87 @@
+/*
+ * Project: UHC
+ * Class: gg.uhc.uhc.modules.CondDisableableModuleEnabled
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package gg.uhc.uhc.skript;
+
+import gg.uhc.uhc.modules.DisableableModule;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+import com.google.common.base.Function;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.bukkit.event.Event;
+
+public class CondDisableableModuleEnabled extends Condition {
+    private Expression<DisableableModule> moduleExpression;
+    private boolean expecting;
+
+    static void hook() {
+        Skript.registerCondition(
+            CondDisableableModuleEnabled.class,
+            "%modules% [(is|are)] (1¦enabled|2¦disabled)"
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(
+        Expression<?>[] exprs,
+        int matchedPattern,
+        Kleenean isDelayed,
+        SkriptParser.ParseResult parseResult
+    ) {
+        moduleExpression = (Expression<DisableableModule>) exprs[0];
+        expecting = parseResult.mark == 1;
+        return true;
+    }
+
+    @Override
+    public boolean check(Event event) {
+        return Iterables.all(
+            Iterables.transform(
+                ImmutableList.copyOf(moduleExpression.getArray(event)),
+                new Function<DisableableModule, Boolean>() {
+                    @Override
+                    public Boolean apply(DisableableModule input) {
+                        return input.isEnabled();
+                    }
+                }
+            ),
+            Predicates.equalTo(expecting)
+        );
+    }
+
+    @Override
+    public String toString(Event event, boolean debug) {
+        return moduleExpression.toString(event, debug) + " is " + (expecting ? "enabled" : "disabled");
+    }
+}

--- a/src/main/java/gg/uhc/uhc/skript/EffDisableableModuleStatus.java
+++ b/src/main/java/gg/uhc/uhc/skript/EffDisableableModuleStatus.java
@@ -1,11 +1,39 @@
+/*
+ * Project: UHC
+ * Class: gg.uhc.uhc.modules.EffDisableableModuleStatus
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package gg.uhc.uhc.skript;
+
+import gg.uhc.uhc.modules.DisableableModule;
 
 import ch.njol.skript.Skript;
 import ch.njol.skript.lang.Effect;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.util.Kleenean;
-import gg.uhc.uhc.modules.DisableableModule;
 import org.bukkit.event.Event;
 
 public class EffDisableableModuleStatus extends Effect {
@@ -21,25 +49,32 @@ public class EffDisableableModuleStatus extends Effect {
 
     @SuppressWarnings("unchecked")
     @Override
-    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+    public boolean init(
+        Expression<?>[] exprs,
+        int matchedPattern,
+        Kleenean isDelayed,
+        SkriptParser.ParseResult parseResult
+    ) {
         moduleExpression = (Expression<DisableableModule>) exprs[0];
         type = Transition.BY_MARK.get(parseResult.mark);
         return true;
     }
 
     @Override
-    protected void execute(Event e) {
-        for (final DisableableModule module : moduleExpression.getArray(e)) {
+    protected void execute(Event event) {
+        for (final DisableableModule module : moduleExpression.getArray(event)) {
             switch (type) {
-            case DISABLE:
-                module.disable();
-                break;
-            case ENABLE:
-                module.enable();
-                break;
-            case TOGGLE:
-                module.toggle();
-                break;
+                case DISABLE:
+                    module.disable();
+                    break;
+                case ENABLE:
+                    module.enable();
+                    break;
+                case TOGGLE:
+                    module.toggle();
+                    break;
+                default:
+                    throw new IllegalStateException();
             }
         }
     }

--- a/src/main/java/gg/uhc/uhc/skript/EffDisableableModuleStatus.java
+++ b/src/main/java/gg/uhc/uhc/skript/EffDisableableModuleStatus.java
@@ -1,0 +1,51 @@
+package gg.uhc.uhc.skript;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Effect;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+import gg.uhc.uhc.modules.DisableableModule;
+import org.bukkit.event.Event;
+
+public class EffDisableableModuleStatus extends Effect {
+    private Expression<DisableableModule> moduleExpression;
+    private Transition type;
+
+    static void hook() {
+        Skript.registerEffect(
+            EffDisableableModuleStatus.class,
+            Transition.COMBINED_PATTERN + " %modules%"
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(Expression<?>[] exprs, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+        moduleExpression = (Expression<DisableableModule>) exprs[0];
+        type = Transition.BY_MARK.get(parseResult.mark);
+        return true;
+    }
+
+    @Override
+    protected void execute(Event e) {
+        for (final DisableableModule module : moduleExpression.getArray(e)) {
+            switch (type) {
+            case DISABLE:
+                module.disable();
+                break;
+            case ENABLE:
+                module.enable();
+                break;
+            case TOGGLE:
+                module.toggle();
+                break;
+            }
+        }
+    }
+
+    @Override
+    public String toString(Event event, boolean debug) {
+        return type.toString().toLowerCase() + " " + moduleExpression.toString(event, debug);
+    }
+}

--- a/src/main/java/gg/uhc/uhc/skript/EvtModuleStatusChange.java
+++ b/src/main/java/gg/uhc/uhc/skript/EvtModuleStatusChange.java
@@ -1,0 +1,81 @@
+/*
+ * Project: UHC
+ * Class: gg.uhc.uhc.modules.EvtModuleStatusChange
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package gg.uhc.uhc.skript;
+
+import gg.uhc.uhc.modules.events.ModuleChangeStatusEvent;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptEventInfo;
+import ch.njol.skript.lang.SkriptParser;
+import org.bukkit.event.Event;
+
+public class EvtModuleStatusChange extends SkriptEvent {
+    private Transition transition;
+
+    static SkriptEventInfo<EvtModuleStatusChange> hook() {
+        return Skript
+            .registerEvent(
+                "UHC Module Status Change",
+                EvtModuleStatusChange.class,
+                ModuleChangeStatusEvent.class,
+                "module[s] " + Transition.COMBINED_PATTERN
+            )
+            .description("Called when modules are enabled/disabled/toggled")
+            .examples("")
+            .since("1.0");
+    }
+
+    @Override
+    public boolean init(final Literal<?>[] args, final int matchedPattern, final SkriptParser.ParseResult parser) {
+        transition = Transition.BY_MARK.get(parser.mark);
+
+        return transition != null;
+    }
+
+    @Override
+    public boolean check(final Event rawEvent) {
+        assert rawEvent instanceof ModuleChangeStatusEvent;
+
+        final ModuleChangeStatusEvent event = (ModuleChangeStatusEvent) rawEvent;
+
+        switch (transition) {
+            case TOGGLE: return true;
+            case ENABLE: return event.willBeEnabled();
+            case DISABLE: return !event.willBeEnabled();
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public String toString(final Event event, final boolean debug) {
+        return "module " + transition.name().toLowerCase();
+    }
+}

--- a/src/main/java/gg/uhc/uhc/skript/ExprDisableableModule.java
+++ b/src/main/java/gg/uhc/uhc/skript/ExprDisableableModule.java
@@ -1,0 +1,124 @@
+/*
+ * Project: UHC
+ * Class: gg.uhc.uhc.modules.ExprDisableableModule
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package gg.uhc.uhc.skript;
+
+import gg.uhc.uhc.modules.DisableableModule;
+import gg.uhc.uhc.modules.Module;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+import com.google.common.base.Function;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.bukkit.event.Event;
+
+public class ExprDisableableModule extends SimpleExpression<DisableableModule> {
+    private Expression<String> names;
+    private boolean multiple;
+
+    static void hook() {
+        Skript.registerExpression(
+            ExprDisableableModule.class,
+            DisableableModule.class,
+            ExpressionType.COMBINED,
+            "[all] modules",
+            "[the] (1¦module|2¦modules) [called] %strings%"
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(
+        Expression<?>[] exprs,
+        int matchedPattern,
+        Kleenean isDelayed,
+        SkriptParser.ParseResult parseResult
+    ) {
+        if (matchedPattern == 0) {
+            names = null;
+        } else {
+            names = (Expression<String>) exprs[0];
+        }
+
+        multiple = parseResult.mark == 2;
+
+        return true;
+    }
+
+    @Override
+    protected DisableableModule[] get(Event event) {
+        if (names == null) {
+            return Iterables.toArray(SkriptHook.getAllModules(), DisableableModule.class);
+        }
+
+        return Iterables.toArray(
+            // Convert into disableable by casting to allow conversion to array
+            Iterables.transform(
+                // Filter out non-existing and non-disableable
+                Iterables.filter(
+                    // Find the module by name (or null if not exists)
+                    Iterables.transform(
+                        ImmutableList.copyOf(names.getArray(event)),
+                        SkriptHook.findModuleByNameFunction()
+                    ),
+                    Predicates.and(
+                        Predicates.notNull(),
+                        Predicates.instanceOf(DisableableModule.class)
+                    )
+                ),
+                new Function<Module, DisableableModule>() {
+                    @Override
+                    public DisableableModule apply(Module input) {
+                        return (DisableableModule) input;
+                    }
+                }
+            ),
+            DisableableModule.class
+        );
+    }
+
+    @Override
+    public boolean isSingle() {
+        return !multiple;
+    }
+
+    @Override
+    public Class<? extends DisableableModule> getReturnType() {
+        return DisableableModule.class;
+    }
+
+    @Override
+    public String toString(Event event, boolean debug) {
+        return names == null ? "all modules" : "the modules " + names.toString(event, debug);
+    }
+}

--- a/src/main/java/gg/uhc/uhc/skript/ExprDisableableModuleName.java
+++ b/src/main/java/gg/uhc/uhc/skript/ExprDisableableModuleName.java
@@ -1,6 +1,6 @@
 /*
  * Project: UHC
- * Class: gg.uhc.uhc.modules.events.ModuleDisableEvent
+ * Class: gg.uhc.uhc.modules.ExpDisableableModuleStatus
  *
  * The MIT License (MIT)
  *
@@ -25,41 +25,32 @@
  * THE SOFTWARE.
  */
 
-package gg.uhc.uhc.modules.events;
+
+package gg.uhc.uhc.skript;
 
 import gg.uhc.uhc.modules.DisableableModule;
 
-import org.bukkit.event.Event;
-import org.bukkit.event.HandlerList;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
 
-public class ModuleDisableEvent extends Event {
-    private static final HandlerList HANDLERS = new HandlerList();
+public class ExprDisableableModuleName extends SimplePropertyExpression<DisableableModule, String> {
+    private static final String PROPERTY = "name";
 
-    protected final DisableableModule module;
-    protected boolean cancelled;
-
-    public ModuleDisableEvent(DisableableModule module) {
-        this.module = module;
+    static void hook() {
+        register(ExprDisableableModuleName.class, String.class, "name[s]", "modules");
     }
 
     @Override
-    public HandlerList getHandlers() {
-        return HANDLERS;
+    protected String getPropertyName() {
+        return PROPERTY;
     }
 
-    public static HandlerList getHandlerList() {
-        return HANDLERS;
+    @Override
+    public String convert(final DisableableModule disableableModule) {
+        return disableableModule.getId();
     }
 
-    public DisableableModule getModule() {
-        return module;
-    }
-
-    public boolean isCancelled() {
-        return cancelled;
-    }
-
-    public void setCancelled(boolean cancelled) {
-        this.cancelled = cancelled;
+    @Override
+    public Class<? extends String> getReturnType() {
+        return String.class;
     }
 }

--- a/src/main/java/gg/uhc/uhc/skript/ExprDisableableModuleStatus.java
+++ b/src/main/java/gg/uhc/uhc/skript/ExprDisableableModuleStatus.java
@@ -1,0 +1,86 @@
+/*
+ * Project: UHC
+ * Class: gg.uhc.uhc.modules.ExpDisableableModuleStatus
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package gg.uhc.uhc.skript;
+
+import gg.uhc.uhc.modules.DisableableModule;
+
+import ch.njol.skript.classes.Changer;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import org.bukkit.event.Event;
+
+public class ExprDisableableModuleStatus extends SimplePropertyExpression<DisableableModule, Boolean> {
+    private static final String PROPERTY = "enabled status";
+
+    static void hook() {
+        register(ExprDisableableModuleStatus.class, Boolean.class, "[enabled] status[es]", "modules");
+    }
+
+    @Override
+    protected String getPropertyName() {
+        return PROPERTY;
+    }
+
+    @Override
+    public Boolean convert(final DisableableModule disableableModule) {
+        return disableableModule.isEnabled();
+    }
+
+    @Override
+    public Class<? extends Boolean> getReturnType() {
+        return Boolean.class;
+    }
+
+    @Override
+    public Class<?>[] acceptChange(final Changer.ChangeMode mode) {
+        if (mode == Changer.ChangeMode.SET) {
+            return new Class[] { Boolean.class };
+        }
+
+        return null;
+    }
+
+    @Override
+    public void change(final Event event, final Object[] delta, final Changer.ChangeMode mode) {
+        if (mode == Changer.ChangeMode.SET) {
+            assert delta != null;
+
+            final boolean newState = (Boolean) delta[0];
+
+            for (final DisableableModule module : getExpr().getArray(event)) {
+                if (newState) {
+                    module.enable();
+                } else {
+                    module.disable();
+                }
+            }
+        } else {
+            super.change(event, delta, mode);
+        }
+    }
+}

--- a/src/main/java/gg/uhc/uhc/skript/ExprGoldenHeadsHealAmount.java
+++ b/src/main/java/gg/uhc/uhc/skript/ExprGoldenHeadsHealAmount.java
@@ -1,0 +1,142 @@
+/*
+ * Project: UHC
+ * Class: gg.uhc.uhc.modules.ExprGoldenHeadsHealAmount
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package gg.uhc.uhc.skript;
+
+import gg.uhc.uhc.modules.DisableableModule;
+import gg.uhc.uhc.modules.heads.GoldenHeadsModule;
+import gg.uhc.uhc.util.Action2;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.classes.Changer;
+import ch.njol.skript.classes.Converter;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Kleenean;
+import com.google.common.collect.ImmutableMap;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.Map;
+
+public class ExprGoldenHeadsHealAmount extends PropertyExpression<DisableableModule, Integer> {
+    private static Map<Changer.ChangeMode, Action2<GoldenHeadsModule, Integer>> ACTIONS =
+        ImmutableMap
+            .<Changer.ChangeMode, Action2<GoldenHeadsModule, Integer>>builder()
+            .put(Changer.ChangeMode.SET, new Action2<GoldenHeadsModule, Integer>() {
+                @Override
+                public void apply(GoldenHeadsModule element, Integer delta) {
+                    element.setHealAmount(delta);
+                }
+            })
+            .put(Changer.ChangeMode.ADD, new Action2<GoldenHeadsModule, Integer>() {
+                @Override
+                public void apply(GoldenHeadsModule element, Integer element2) {
+                    element.setHealAmount(element.getHealAmount() + element2);
+                }
+            })
+            .put(Changer.ChangeMode.REMOVE, new Action2<GoldenHeadsModule, Integer>() {
+                @Override
+                public void apply(GoldenHeadsModule element, Integer element2) {
+                    element.setHealAmount(element.getHealAmount() - element2);
+                }
+            })
+            .build();
+
+    static void hook() {
+        Skript.registerExpression(
+                ExprGoldenHeadsHealAmount.class,
+                Integer.class,
+                ExpressionType.PROPERTY,
+                "[the] heal amount of %module%", "%module%'[s] heal amount");
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean init(
+            final Expression<?>[] exprs,
+            final int matchedPattern,
+            final Kleenean isDelayed,
+            final SkriptParser.ParseResult parseResult
+    ) {
+        setExpr((Expression<GoldenHeadsModule>) exprs[0]);
+        return true;
+    }
+
+    @Override
+    protected Integer[] get(Event event, DisableableModule[] source) {
+        return get(source, new Converter<DisableableModule, Integer>() {
+            @Override
+            public Integer convert(final DisableableModule module) {
+                if (module instanceof GoldenHeadsModule) {
+                    return ((GoldenHeadsModule) module).getHealAmount();
+                }
+
+                Skript.error("Cannot get heal amount from module " + module.getId());
+                throw new UnsupportedOperationException();
+            }
+        });
+    }
+
+    @Override
+    public Class<? extends Integer> getReturnType() {
+        return Integer.class;
+    }
+
+    @Override
+    @Nullable
+    public Class<?>[] acceptChange(final Changer.ChangeMode mode) {
+        return ACTIONS.containsKey(mode) ? new Class[] { Integer.class } : super.acceptChange(mode);
+    }
+
+    @Override
+    public void change(final Event event, final Object[] delta, final Changer.ChangeMode mode) {
+        final int castDelta = (Integer) delta[0];
+        final Action2<GoldenHeadsModule, Integer> action = ACTIONS.get(mode);
+
+        if (action == null) {
+            super.change(event, delta, mode);
+            return;
+        }
+
+        for (final DisableableModule module : getExpr().getArray(event)) {
+            if (!(module instanceof GoldenHeadsModule)) {
+                Skript.error("Cannot modify the heal amount of module: " + module.getId());
+                continue;
+            }
+
+            action.apply((GoldenHeadsModule) module, castDelta);
+        }
+    }
+
+    @Override
+    public String toString(Event event, boolean debug) {
+        return "the heal amount of " + getExpr().toString(event, debug);
+    }
+}

--- a/src/main/java/gg/uhc/uhc/skript/SkriptHook.java
+++ b/src/main/java/gg/uhc/uhc/skript/SkriptHook.java
@@ -109,6 +109,9 @@ public final class SkriptHook {
         EffDisableableModuleStatus.hook();
         logger.info("Registered module status efffect");
 
+        ExprGoldenHeadsHealAmount.hook();
+        logger.info("Registered golden heal heal amount expression");
+
         EventValues.registerEventValue(
             ModuleChangeStatusEvent.class,
             DisableableModule.class,

--- a/src/main/java/gg/uhc/uhc/skript/SkriptHook.java
+++ b/src/main/java/gg/uhc/uhc/skript/SkriptHook.java
@@ -27,13 +27,6 @@
 
 package gg.uhc.uhc.skript;
 
-import ch.njol.skript.classes.Changer;
-import ch.njol.skript.expressions.base.EventValueExpression;
-import ch.njol.skript.lang.DefaultExpression;
-import ch.njol.skript.lang.Expression;
-import ch.njol.skript.lang.SkriptParser;
-import ch.njol.util.Checker;
-import ch.njol.util.Kleenean;
 import gg.uhc.uhc.UHC;
 import gg.uhc.uhc.modules.DisableableModule;
 import gg.uhc.uhc.modules.Module;
@@ -43,16 +36,14 @@ import gg.uhc.uhc.modules.events.ModuleChangeStatusEvent;
 import ch.njol.skript.Skript;
 import ch.njol.skript.SkriptAddon;
 import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.expressions.base.EventValueExpression;
 import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.util.Getter;
 import com.google.common.base.Function;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
-import org.bukkit.entity.Entity;
-import org.bukkit.event.Event;
 
-import java.util.Iterator;
 import java.util.logging.Logger;
 
 public final class SkriptHook {

--- a/src/main/java/gg/uhc/uhc/skript/SkriptHook.java
+++ b/src/main/java/gg/uhc/uhc/skript/SkriptHook.java
@@ -1,0 +1,134 @@
+/*
+ * Project: UHC
+ * Class: gg.uhc.uhc.modules.SkriptHook
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package gg.uhc.uhc.skript;
+
+import ch.njol.skript.classes.Changer;
+import ch.njol.skript.expressions.base.EventValueExpression;
+import ch.njol.skript.lang.DefaultExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.util.Checker;
+import ch.njol.util.Kleenean;
+import gg.uhc.uhc.UHC;
+import gg.uhc.uhc.modules.DisableableModule;
+import gg.uhc.uhc.modules.Module;
+import gg.uhc.uhc.modules.ModuleRegistry;
+import gg.uhc.uhc.modules.events.ModuleChangeStatusEvent;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.SkriptAddon;
+import ch.njol.skript.classes.ClassInfo;
+import ch.njol.skript.registrations.Classes;
+import ch.njol.skript.registrations.EventValues;
+import ch.njol.skript.util.Getter;
+import com.google.common.base.Function;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.Event;
+
+import java.util.Iterator;
+import java.util.logging.Logger;
+
+public final class SkriptHook {
+    private static ModuleRegistry registry;
+
+    private SkriptHook() {}
+
+    static Function<String, Module> findModuleByNameFunction() {
+        return new Function<String, Module>() {
+            @Override
+            public Module apply(String input) {
+                return SkriptHook.registry.get(input).orNull();
+            }
+        };
+    }
+
+    static Iterable<DisableableModule> getAllModules() {
+        return Iterables.transform(
+            Iterables.filter(
+                registry.getModules(),
+                Predicates.instanceOf(DisableableModule.class)
+            ),
+            new Function<Module, DisableableModule>() {
+                @Override
+                public DisableableModule apply(Module input) {
+                    return (DisableableModule) input;
+                }
+            }
+        );
+    }
+
+    public static void register(final UHC uhc) {
+        registry = uhc.getRegistry();
+
+        final SkriptAddon addon = Skript.registerAddon(uhc);
+        final Logger logger = uhc.getLogger();
+        logger.info("Registered skript addon " + addon);
+
+        Classes.registerClass(
+            new ClassInfo<>(DisableableModule.class, "module")
+                    .user("modules?")
+                    .name("UHC Module")
+                    .usage("")
+                    .examples("")
+                    .defaultExpression(new EventValueExpression<>(DisableableModule.class))
+        );
+        logger.info("Regiseted module class");
+
+        logger.info("Registered event: " + EvtModuleStatusChange.hook());
+
+        ExprDisableableModule.hook();
+        logger.info("Registered module name expression");
+
+        ExprDisableableModuleStatus.hook();
+        logger.info("Registered module status expression");
+
+        ExprDisableableModuleName.hook();
+        logger.info("Registered module name expression");
+
+        CondDisableableModuleEnabled.hook();
+        logger.info("Registered enabled condition");
+
+        EffDisableableModuleStatus.hook();
+        logger.info("Registered module status efffect");
+
+        EventValues.registerEventValue(
+            ModuleChangeStatusEvent.class,
+            DisableableModule.class,
+            new Getter<DisableableModule, ModuleChangeStatusEvent>() {
+                @Override
+                public DisableableModule get(ModuleChangeStatusEvent arg) {
+                    return arg.getModule();
+                }
+            },
+            0
+        );
+        logger.info("Regiseterd event value for module");
+    }
+}

--- a/src/main/java/gg/uhc/uhc/skript/Transition.java
+++ b/src/main/java/gg/uhc/uhc/skript/Transition.java
@@ -1,0 +1,53 @@
+package gg.uhc.uhc.skript;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+enum Transition {
+    ENABLE("enable[d]", 1),
+    DISABLE("disable[d]", 2),
+    TOGGLE("(change state|toggle[d])", 3);
+
+    static final Map<Integer, Transition> BY_MARK;
+    static final String COMBINED_PATTERN;
+
+    static {
+        final ImmutableMap.Builder<Integer, Transition> temp = ImmutableMap.builder();
+
+        final StringBuilder sb = new StringBuilder();
+        sb.append("(");
+
+        for (final Transition transition : Transition.values()) {
+            temp.put(transition.getMark(), transition);
+            sb
+                .append(transition.getMark())
+                .append('¦')
+                .append(transition.pattern)
+                .append("|");
+        }
+
+        sb
+            .deleteCharAt(sb.lastIndexOf("|"))
+            .append(")");
+
+        BY_MARK = temp.build();
+        COMBINED_PATTERN = sb.toString();
+    }
+
+    private final String pattern;
+    private final int mark;
+
+    Transition(String pattern, int mark) {
+        this.pattern = pattern;
+        this.mark = mark;
+    }
+
+    String getPattern() {
+        return pattern;
+    }
+
+    int getMark() {
+        return mark;
+    }
+}

--- a/src/main/java/gg/uhc/uhc/skript/Transition.java
+++ b/src/main/java/gg/uhc/uhc/skript/Transition.java
@@ -1,3 +1,30 @@
+/*
+ * Project: UHC
+ * Class: gg.uhc.uhc.modules.Transition
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package gg.uhc.uhc.skript;
 
 import com.google.common.collect.ImmutableMap;

--- a/src/main/java/gg/uhc/uhc/util/Action.java
+++ b/src/main/java/gg/uhc/uhc/util/Action.java
@@ -1,0 +1,32 @@
+/*
+ * Project: UHC
+ * Class: gg.uhc.uhc.util.Action
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package gg.uhc.uhc.util;
+
+public interface Action<T> {
+    void apply(T element);
+}

--- a/src/main/java/gg/uhc/uhc/util/Action2.java
+++ b/src/main/java/gg/uhc/uhc/util/Action2.java
@@ -1,0 +1,32 @@
+/*
+ * Project: UHC
+ * Class: gg.uhc.uhc.util.Action2
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Graham Howden <graham_howden1 at yahoo.co.uk>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package gg.uhc.uhc.util;
+
+public interface Action2<T, T2> {
+    void apply(T element, T2 element2);
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ version: ${project.version}
 author: ghowden/Eluinhost
 database: false
 soft-depend: [ProtocolLib]
+loadbefore: [Skript]
 commands:
   showhealth:
     permission: uhc.command.showhealth


### PR DESCRIPTION
Current docs:

## Events

 - On module change status
   - Description: Trigger on module enable/disable/toggles
   - Pattern: `module[s] ((change state|toggle[d])|enable[d]|disable[d])`
   - Examples:
     - `on module toggled` - Called whenever any module is toggled
     - `on modules enabled` - Called whenever any module is enabled

## Expressions

- Get module by name
  - Pattern: `[the] module[s] called %strings%`
  
- Get module's name
  - Patterns: 
    - `[the] name[s] of %modules%"`
    - `%modules%'[s] name`
  
- Get module's enabled status (boolean)
  - Patterns: 
    - `[the] [enabled] status[es] of %modules%"`
    - `"%modules%'[s] [enabled] status[es]`
  
- Get golden head heal amount
  - Patterns: 
    - `[the] heal amount of %module%`
    - `"%module%'[s] heal amount`
  
## Conditions

- Check module status
  - Description: Checks if all of the modules requested are enabled/disabled
  - Pattern: `if %modules?% (is|are) (enabled|disabled)`
  - Examples:
    - `if the module "PVP" is enabled:`
    - `if all modules are disabled:`
    
## Effects

- Change status of module
  - Description: Enables/Disables/Toggles the request modules
  - Pattern: `((change state|toggle[d])|enable[d]|disable[d]) %modules%`
  - Examples:
    - `disable all modules`
    - `enable the module called "PvP"`
    - `disable the modules called "GoldenHeads", "ExtendedSaturation" and "ChatHealth"`
    